### PR TITLE
Add a readme for route53_hosted_zone

### DIFF
--- a/modules/route53_hosted_zone/README.md
+++ b/modules/route53_hosted_zone/README.md
@@ -1,0 +1,17 @@
+# Route53 Hosted Zone
+
+This simple module creates a hosted zone tagged with a common set of variables.
+
+# Usage
+
+```hcl
+terraform {
+  source = "git@github.com:vytautaskubilius/infrastructure-modules.git//modules/route53_hosted_zone"
+}
+
+inputs = {
+  name        = "kumetynas.lt"
+  environment = "production"
+  project     = "kumetynas"
+}
+```

--- a/modules/route53_hosted_zone/dependencies.tf
+++ b/modules/route53_hosted_zone/dependencies.tf
@@ -1,0 +1,8 @@
+locals {
+  common_tags = merge({
+    environment = var.environment
+    }, {
+    project = var.project
+    },
+  var.tags)
+}

--- a/modules/route53_hosted_zone/main.tf
+++ b/modules/route53_hosted_zone/main.tf
@@ -1,0 +1,4 @@
+resource "aws_route53_zone" "zone" {
+  name = var.name
+  tags = local.common_tags
+}

--- a/modules/route53_hosted_zone/outputs.tf
+++ b/modules/route53_hosted_zone/outputs.tf
@@ -1,0 +1,7 @@
+output "hosted_zone_id" {
+  value = aws_route53_zone.zone.id
+}
+
+output "name_servers" {
+  value = aws_route53_zone.zone.name_servers
+}

--- a/modules/route53_hosted_zone/vars.tf
+++ b/modules/route53_hosted_zone/vars.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "Hosted zone name"
+}
+
+variable "environment" {
+  description = "Environment into which this module is being deployed"
+  type        = string
+}
+
+variable "project" {
+  description = "The project into which this module is being deployed (used for tagging resources)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Map of additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR adds a `README.md` file for the `route53_hosted_zone` module.