### PR TITLE
Add a module for deploying a WordPress instance

### DIFF
--- a/modules/wordpress-instance/README.md
+++ b/modules/wordpress-instance/README.md
@@ -1,0 +1,46 @@
+# Instance with WordPress deployed
+
+This module deploys an AWS instance with WordPress installed on it. It also creates Route53 DNS records for the website,
+and an S3 bucket for hosting DB backups with an IAM instance profile that allows the instance to upload the DB dumps.
+
+The module doesn't deploy a key pair for connecting to the instance - that needs to be done manually (the key pair name
+is supplied as an input variable). DB passwords are expected to be stored in AWS SSM Parameter Store with names
+that follow this convention:
+
+```hcl
+data "aws_ssm_parameter" "mysql_root_password" {
+  name = "${var.domain}_mysql_root_password"
+}
+
+data "aws_ssm_parameter" "mysql_wordpressuser_password" {
+  name = "${var.domain}_mysql_wordpressuser_password"
+}
+```
+
+# Usage 
+
+This module expects the VPC and the Route53 hosted zone to have been deployed beforehand as it requires the VPC ID,
+subnet ID, and hosted zone ID to be supplied as input variables.
+
+```hcl
+dependency "vpc" {
+  config_path = "${get_terragrunt_dir()}/../../network/vpc"
+}
+
+dependency "hosted_zone" {
+  config_path = "${get_terragrunt_dir()}/../../network/route53/hosted_zone"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+  subnet_id = dependency.vpc.outputs.public_subnet_id
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+  key_pair_name = "kumetynas-production"
+  domain = "kumetynas.lt"
+}
+
+```
+
+# TODO
+
+- DB backup script.

--- a/modules/wordpress-instance/dependencies.tf
+++ b/modules/wordpress-instance/dependencies.tf
@@ -1,0 +1,49 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/user-data.sh")
+
+  vars = {
+    domain                       = var.domain
+    mysql_root_password          = data.aws_ssm_parameter.mysql_root_password.value
+    mysql_wordpressuser_password = data.aws_ssm_parameter.mysql_wordpressuser_password.value
+  }
+}
+
+data "aws_ssm_parameter" "mysql_root_password" {
+  name = "${var.domain}_mysql_root_password"
+}
+
+data "aws_ssm_parameter" "mysql_wordpressuser_password" {
+  name = "${var.domain}_mysql_wordpressuser_password"
+}
+
+data "aws_iam_policy_document" "instance_profile" {
+  statement {
+    sid = "AllowS3ObjectReadWrite"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:*Object*"
+    ]
+    effect    = "Allow"
+    resources = [
+      aws_s3_bucket.backup.arn,
+      "${aws_s3_bucket.backup.arn}/*"
+    ]
+  }
+}

--- a/modules/wordpress-instance/dependencies.tf
+++ b/modules/wordpress-instance/dependencies.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "instance_profile" {
       "s3:ListBucket",
       "s3:*Object*"
     ]
-    effect    = "Allow"
+    effect = "Allow"
     resources = [
       aws_s3_bucket.backup.arn,
       "${aws_s3_bucket.backup.arn}/*"

--- a/modules/wordpress-instance/main.tf
+++ b/modules/wordpress-instance/main.tf
@@ -1,0 +1,102 @@
+resource "aws_instance" "wordpress" {
+  ami                  = data.aws_ami.ubuntu.id
+  instance_type        = var.instance_type
+  key_name             = var.key_pair_name
+  subnet_id            = var.subnet_id
+  user_data            = data.template_file.user_data.rendered
+  iam_instance_profile = aws_iam_instance_profile.wordpress.name
+  security_groups      = [aws_security_group.wordpress.id]
+}
+
+resource "aws_security_group" "wordpress" {
+  name        = "${var.domain} inbound allow"
+  description = "Traffic allowed to reach the instance that serves ${var.domain}"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "http" {
+  from_port         = 80
+  to_port           = 80
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.wordpress.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "https" {
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.wordpress.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "ssh" {
+  from_port         = 22
+  to_port           = 22
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.wordpress.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "allow_all_outbound" {
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.wordpress.id
+  type              = "egress"
+}
+
+resource "aws_iam_role" "wordpress" {
+  name               = "wordpress-instance-role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "wordpress" {
+  name = "wordpress"
+  role = aws_iam_role.wordpress.name
+}
+
+resource "aws_iam_role_policy" "wordpress" {
+  policy = data.aws_iam_policy_document.instance_profile.json
+  role   = aws_iam_role.wordpress.id
+}
+
+resource "aws_s3_bucket" "backup" {
+  bucket = "${var.domain}-backup"
+  acl    = "private"
+}
+
+resource "aws_route53_record" "root" {
+  name    = var.domain
+  type    = "A"
+  zone_id = var.hosted_zone_id
+  records = [aws_instance.wordpress.public_ip]
+  ttl     = 300
+}
+
+resource "aws_route53_record" "www" {
+  name    = "www.${var.domain}"
+  type    = "A"
+  zone_id = var.hosted_zone_id
+  records = [aws_instance.wordpress.public_ip]
+  ttl     = 300
+}
+

--- a/modules/wordpress-instance/outputs.tf
+++ b/modules/wordpress-instance/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_ip" {
+  value = aws_instance.wordpress.public_ip
+}

--- a/modules/wordpress-instance/user-data.sh
+++ b/modules/wordpress-instance/user-data.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -ex
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+# This script is set up using https://www.digitalocean.com/community/tutorials/how-to-install-wordpress-on-ubuntu-20-04-with-a-lamp-stack
+# as a guide.
+
+sudo apt update
+
+# Install LAMP components, Wordpress, and other necessary packages
+sudo apt install -y awscli fail2ban apache2 mysql-server php libapache2-mod-php php-mysql php-curl php-gd php-mbstring php-xml php-xmlrpc php-soap php-intl php-zip
+
+# Clean up MySQL insecure defaults similar to what mysql_secure_installation would do
+# Taken from https://lowendbox.com/blog/automating-mysql_secure_installation-in-mariadb-setup/
+# and adapted to address a deprecated feature for resetting the password.
+sudo mysql -sfu root <<EOT
+-- set root password
+ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${mysql_root_password}';
+-- delete anonymous users
+DELETE FROM mysql.user WHERE User='';
+-- delete remote root capabilities
+DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
+-- drop database 'test'
+DROP DATABASE IF EXISTS test;
+-- also make sure there are lingering permissions to it
+DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+-- make changes immediately
+FLUSH PRIVILEGES;
+EOT
+
+# Create the database for WordPress
+sudo mysql -sfu root -p${mysql_root_password} <<EOT
+CREATE DATABASE wordpress DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+CREATE USER 'wordpressuser'@'%' IDENTIFIED WITH mysql_native_password BY '${mysql_wordpressuser_password}';
+GRANT ALL ON wordpress.* TO 'wordpressuser'@'%';
+FLUSH PRIVILEGES;
+EOT
+
+# Download WordPress and perform some initial setup
+curl -O -s https://wordpress.org/wordpress-5.8.tar.gz
+sudo tar xzf wordpress-5.8.tar.gz
+sudo touch wordpress/.htaccess
+sudo cp wordpress/wp-config-sample.php wordpress/wp-config.php
+sudo mkdir /wordpress/wp-content/upgrade
+sudo cp -a wordpress/. /var/www/${domain}
+sudo chown -R www-data:www-data /var/www/${domain}
+sudo find /var/www/${domain}/ -type d -exec chmod 750 {} \;
+sudo find /var/www/${domain}/ -type f -exec chmod 640 {} \;
+# Next bit taken from https://stackoverflow.com/a/6233537
+SALT=$(curl -s -L https://api.wordpress.org/secret-key/1.1/salt/)
+STRING='put your unique phrase here'
+printf '%s\n' "g/$STRING/d" a "$SALT" . w | ed -s /var/www/${domain}/wp-config.php
+# Fill in the DB parameters in the config file
+sed -i 's/database_name_here/wordpress/' /var/www/${domain}/wp-config.php
+sed -i 's/username_here/wordpressuser/' /var/www/${domain}/wp-config.php
+sed -i 's/password_here/${mysql_wordpressuser_password}/' /var/www/${domain}/wp-config.php
+echo "define('FS_METHOD', 'direct');" >> /var/www/${domain}/wp-config.php
+
+# Create Apache config for the website
+cat <<EOT >> /etc/apache2/sites-available/${domain}.conf
+<VirtualHost *:80>
+    ServerName ${domain}
+    ServerAlias www.${domain}
+    DocumentRoot /var/www/${domain}
+    ErrorLog $${APACHE_LOG_DIR}/error.log
+    CustomLog $${APACHE_LOG_DIR}/access.log combined
+    <Directory /var/www/${domain}/>
+        AllowOverride All
+    </Directory>
+</VirtualHost>
+EOT
+
+# Enable mod_rewrite for prettier URIs
+sudo a2enmod rewrite
+
+sudo a2ensite ${domain}
+sudo a2dissite 000-default
+
+# Set up Let's Encrypt
+
+sudo snap install core; sudo snap refresh core
+sudo apt -y remove certbot
+sudo snap install --classic certbot
+sudo ln -s /snap/bin/certbot /usr/bin/certbot
+sudo certbot --apache --non-interactive --agree-tos -m vytautas.kubilius@gmail.com --domains ${domain},www.${domain}
+
+sudo systemctl reload apache2

--- a/modules/wordpress-instance/vars.tf
+++ b/modules/wordpress-instance/vars.tf
@@ -1,0 +1,30 @@
+variable "instance_type" {
+  description = "Instance type to use with the deployment"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID into which to deploy the instance"
+  type        = string
+}
+
+variable "key_pair_name" {
+  description = "Name of the key pair to use with the instance"
+  type        = string
+}
+
+variable "domain" {
+  description = "Domain name for the website"
+  type        = string
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID into which to deploy the DNS records for the website"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC into which the resources will be deployed"
+  type        = string
+}


### PR DESCRIPTION
This PR adds a module that deploys an AWS instance that hosts a WordPress installation, and its relevant supporting infrastructure components.