### PR TITLE
Add a module for creating Route53 DNS records

### DIFF
--- a/modules/route53_dns_record/README.md
+++ b/modules/route53_dns_record/README.md
@@ -1,0 +1,29 @@
+# Route53 DNS record
+
+This simple module takes a map of DNS records and creates them in AWS Route53.
+
+# Usage
+
+```hcl
+terraform {
+  source = "git@github.com:vytautaskubilius/infrastructure-modules.git//modules/route53_dns_record"
+}
+
+dependency "hosted_zone" {
+  config_path = "${get_terragrunt_dir()}/../hosted_zone"
+}
+
+inputs = {
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+  record_map = {
+    "www.example.cpm" = {
+      type = "CNAME"
+      records = ["example.com"]
+    },
+    "api.kumetynas.lt" = {
+      type = "A"
+      records = ["1.2.3.4"]
+    }
+  }
+}
+```

--- a/modules/route53_dns_record/main.tf
+++ b/modules/route53_dns_record/main.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "record" {
+  for_each = var.record_map
+
+  zone_id = var.hosted_zone_id
+  name    = each.key
+  type    = each.value.type
+  records = each.value.records
+  ttl     = var.ttl
+}

--- a/modules/route53_dns_record/vars.tf
+++ b/modules/route53_dns_record/vars.tf
@@ -1,0 +1,15 @@
+variable "record_map" {
+  description = "Map of DNS records to be created. Map is expected to use the DNS record name as key, and type and record value list as map values"
+  type        = any
+}
+
+variable "hosted_zone_id" {
+  description = "Hosted zone ID where the records will be created."
+  type        = string
+}
+
+variable "ttl" {
+  description = "Time to Live value to set on the DNS record(s)"
+  type        = number
+  default     = 300
+}


### PR DESCRIPTION
This PR creates a module for deploying DNS records to Route53.