### PR TITLE
Enable versioning and set up a lifecycle policy for S3 backups

### DIFF
--- a/modules/wordpress-instance/main.tf
+++ b/modules/wordpress-instance/main.tf
@@ -85,6 +85,20 @@ resource "aws_s3_bucket" "backup" {
   versioning {
     enabled = true
   }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 14
+    }
+  }
 }
 
 resource "aws_route53_record" "root" {


### PR DESCRIPTION
This PR enables versioning on the backup S3 bucket and sets up a lifecycle policy to expire old backups after 14 days.