### PR TITLE
Add missing command to backup cronjob

### DIFF
--- a/modules/wordpress-instance/user-data.sh
+++ b/modules/wordpress-instance/user-data.sh
@@ -107,7 +107,7 @@ EOT
 # Create a cron job to perform daily backups
 
 sudo crontab<<EOT
-0 3 * * * /opt/scripts/backup.sh
+0 3 * * * bash /opt/scripts/backup.sh
 EOT
 
 sudo systemctl reload apache2


### PR DESCRIPTION
This PR adds a missing `bash` command to the cronjob that is supposed to perform daily backups of the WordPress instance.