### PR TITLE
Un-hardcode domain name parameters from the user-data script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2021-08-30
+
+## Changed
+
+- The WordPress instance module no longer references hardcoded domain name parameters.
+
 ## [0.2.3] - 2021-08-26
 
 ## Changed
@@ -51,6 +57,7 @@ Instead, the tags should be specified via the `default_tags` block in the `aws` 
 - Module for creating auto-validating ACM certificates.
 - Module for creating infrastructure for hosting a static website with CloudFront and S3.
 
+[0.2.3]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.0...v0.2.1

--- a/modules/wordpress-instance/user-data.sh
+++ b/modules/wordpress-instance/user-data.sh
@@ -94,12 +94,12 @@ sudo chown ubuntu:ubuntu /opt/scripts
 
 sudo cat <<EOT >> /opt/scripts/backup.sh
 mysqldump -u root -p${mysql_root_password} -A -B > dump.sql
-tar Pczf backup.tar.gz /var/www/kumetynas.lt dump.sql
-aws s3 cp backup.tar.gz s3://kumetynas.lt-backup/backup.tar.gz
+tar Pczf backup.tar.gz /var/www/${domain} dump.sql
+aws s3 cp backup.tar.gz s3://${domain}-backup/backup.tar.gz
 EOT
 
 sudo cat <<EOT >> /opt/scripts/restore.sh
-aws s3 cp s3://kumetynas.lt-backup/backup.tar.gz backup.tar.gz
+aws s3 cp s3://${domain}-backup/backup.tar.gz backup.tar.gz
 tar Pxzf backup.tar.gz
 mysql -u root -p${mysql_root_password} < dump.sql
 EOT


### PR DESCRIPTION
This PR fixes an oversight where hardcoded domain name parameters were left in the user-data script for the `wordpress-instance` module.