### PR TITLE
Move domain name to map values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2021-10-09
+
+## Changed
+
+- The `route53_dns_record` module now requires the DNS record name to be provided as a value instead of it being read
+  in from the map key.
+  - This is to allow for the creation of multiple records of different types with the same name.
+
 ## [0.2.4] - 2021-08-30
 
 ## Changed
@@ -57,6 +65,7 @@ Instead, the tags should be specified via the `default_tags` block in the `aws` 
 - Module for creating auto-validating ACM certificates.
 - Module for creating infrastructure for hosting a static website with CloudFront and S3.
 
+[0.3.0]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.4...v0.3.0
 [0.2.3]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/vytautaskubilius/infrastructure-modules/compare/v0.2.1...v0.2.2

--- a/modules/route53_dns_record/README.md
+++ b/modules/route53_dns_record/README.md
@@ -1,6 +1,7 @@
 # Route53 DNS record
 
-This simple module takes a map of DNS records and creates them in AWS Route53.
+This simple module takes a map of DNS records and creates them in AWS Route53. The keys in the `record_map` must be
+unique.
 
 # Usage
 
@@ -16,13 +17,30 @@ dependency "hosted_zone" {
 inputs = {
   hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
   record_map = {
-    "www.example.cpm" = {
+    "www.dontpanic.lt" = {
+      name = "www.dontpanic.lt"
       type = "CNAME"
       records = ["example.com"]
     },
-    "api.kumetynas.lt" = {
+    "api.dontpanic.lt" = {
+      name = "api.dontpanic.lt"
       type = "A"
       records = ["1.2.3.4"]
+    },
+    "dontpanic.lt-mx" = {
+      name = "dontpanic.lt"
+      type = "MX"
+      records = [
+        "10 mx1.example.com",
+        "20 mx2.example.com"
+      ]
+    },
+    "dontpanic.lt-txt" = {
+      name = "dontpanic.lt"
+      type = "TXT"
+      records = [
+        "example"
+      ]
     }
   }
 }

--- a/modules/route53_dns_record/main.tf
+++ b/modules/route53_dns_record/main.tf
@@ -2,7 +2,7 @@ resource "aws_route53_record" "record" {
   for_each = var.record_map
 
   zone_id = var.hosted_zone_id
-  name    = each.key
+  name    = each.value.name
   type    = each.value.type
   records = each.value.records
   ttl     = var.ttl


### PR DESCRIPTION
This PR changes the `route53_dns_record` module so that the domain name is read from the `name` value of the `record_map` map. This is done so that the configuration would allow multiple records with the same name to be created (e.g. when both TXT and MX records need to be created on the root domain).